### PR TITLE
Highlights the need to use dash separated attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ markup.
 
 FlexSlider initialization properties can be specified as attributes of `flex-slider`
 directive using dash separated attributes instead of cammel case.
-For example, the property `controlNav` can be specified via the attribute `control-nav`.
+
+**For example, the property `controlNav` can be specified via the attribute `control-nav`.**
 
 The FlexSlider callback API can also be used by specifying attributes with the
 appropriate API name containing [AngularJS expressions](http://docs.angularjs.org/guide/expression).


### PR DESCRIPTION
This is a fundamental difference in using flexslider and the directive. Hopefully this minor tweak to the styling of the readme will help save time for other developers.
