### PR TITLE
Update removeSlide in $watchCollection to use oldCollection, rather than the new collection

### DIFF
--- a/angular-flexslider.coffee
+++ b/angular-flexslider.coffee
@@ -68,7 +68,7 @@ angular.module('angular-flexslider', [])
 						if (toAdd.length == 1 and toRemove.length == 0) or toAdd.length == 0
 							# Remove items
 							for e in toRemove
-								e = removeSlide e, collection.indexOf(e)
+								e = removeSlide e, oldCollection.indexOf(e)
 								slider.removeSlide e.element if e
 							# Add items
 							for e in toAdd

--- a/angular-flexslider.js
+++ b/angular-flexslider.js
@@ -100,7 +100,7 @@
                 if ((toAdd.length === 1 && toRemove.length === 0) || toAdd.length === 0) {
                   for (_j = 0, _len1 = toRemove.length; _j < _len1; _j++) {
                     e = toRemove[_j];
-                    e = removeSlide(e, collection.indexOf(e));
+                    e = removeSlide(e, oldCollection.indexOf(e));
                     if (e) {
                       slider.removeSlide(e.element);
                     }


### PR DESCRIPTION
After running into the same issue mentioned in https://github.com/thenikso/angular-flexslider/issues/53, I found the fix in my case was to make sure we're checking the old collection of slides for the element to the remove.  When using the new collection, the value was no longer present, causing the error.